### PR TITLE
feat: do not push index.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .rslib
+packages/component/index.ts

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "prebuild": "esno internal/create-core-entry.ts && pnpm --filter @qwqui/* clean:dist",
+    "predev": "esno internal/create-core-entry.ts && pnpm --filter @qwqui/* clean:dist",
     "test:type": "tsc --noEmit",
     "test": "jest",
     "build": "pnpm --filter !@qwqui/core build && pnpm --filter @qwqui/core build",

--- a/packages/components/index.ts
+++ b/packages/components/index.ts
@@ -1,5 +1,0 @@
-import './drop-zone/src/style.scss'
-import './ripple/src/ripple.module.scss'
-export * from './button/index.ts'
-export * from './drop-zone/index.ts'
-export * from './ripple/index.ts'


### PR DESCRIPTION
The `index.ts` must not be push. Because it is just used for publishing core packages (aka all components) or used in doc